### PR TITLE
src/App.js: set flex item width = 1

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,6 +45,7 @@ function App() {
       padding: 10,
       borderRadius: 4,
       boxShadow: '1px 1px 2px #999',
+      width: 1,
     },
     buttons: {
       display: 'flex',


### PR DESCRIPTION
This avoids stacking the panel and the player controls on firefox browser.

# Before (ff 80.0, macOS 10.14)

![image](https://user-images.githubusercontent.com/1524005/92977360-a9f9e680-f441-11ea-868d-7ba5afae815b.png)

# After (ff 80.0, macOS 10.14)

![image](https://user-images.githubusercontent.com/1524005/92977428-db72b200-f441-11ea-9582-c11c3c8233af.png)

----------------------

@slavik0329 what browsers are you regularly testing with? i noticed no problems in Google Chrome 85 or Safari 13.1