### PR TITLE
NowPlaying.js: reduce tick() pileup

### DIFF
--- a/src/NowPlaying.js
+++ b/src/NowPlaying.js
@@ -67,18 +67,11 @@ export function NowPlaying({call, freqData}) {
   };
   const [tickOn, setTickOn] = useState(true);
 
-  const tickRef = useState(true);
-
-  function tick() {
-    tickRef.current = !tickRef.current;
-
-    setTickOn(tickRef.current);
-    setTimeout(tick, 1000);
-  }
-
   useEffect(() => {
-    tick();
-  }, [tick]);
+    setTimeout(function () {
+      setTickOn(!tickOn)
+    }, 1000);
+  }, [tickOn]);
 
   let callInfo = {
     file: 'Not Playing',


### PR DESCRIPTION
Rewrite the `useEffect` `tick()` now playing ':' animation to only fire once per second. The timeout function shouldn't be re-scheduling itself, so rely on `useEffect` to reschedule the tick.

The previous implementation would pile up multiple calls to `tick()` which would trigger a waterfall of re-renders causing CPU usage to spike and continue to increase the longer the page was left open.

This change should improve battery life on mobile.

Tested in Firefox 80.0.1 and Chrome 85.0.4183.121 on macOS 10.14

Tested in Brave 1.14.83 (Chromium 85.0.4183.102) on Android 11