### PR TITLE
Improve listened and autoplay handling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -483,7 +483,8 @@ function App() {
 
               playNext();
             }}
-            autoPlay={autoplay}
+            // set autoPlay for taps and keyboard input
+            autoPlay="true"
             preload={'none'}
             src={selected ? `${serverUrl}static/${selected}` : null}
             controls

--- a/src/App.js
+++ b/src/App.js
@@ -218,9 +218,9 @@ function App() {
     //
     // }
 
+    setListenedArr([...listenedArr, selected]);
     if (nextCall) {
       setSelected(nextCall.file);
-      setListenedArr([...listenedArr, nextCall.file]);
     }
   };
 
@@ -525,9 +525,9 @@ function App() {
                     freqData={freqData}
                     setFreqData={setFreqData}
                     onClick={() => {
+                      setListenedArr([...listenedArr, selected]);
                       setSelected(call.file);
 
-                      setListenedArr([...listenedArr, call.file]);
                     }}
                     onLike={() => {
                       setLikedArr([...likedArr, call.freq]);

--- a/src/App.js
+++ b/src/App.js
@@ -484,7 +484,7 @@ function App() {
               playNext();
             }}
             // set autoPlay for taps and keyboard input
-            autoPlay="true"
+            autoPlay={true}
             preload={'none'}
             src={selected ? `${serverUrl}static/${selected}` : null}
             controls


### PR DESCRIPTION
# `setListenedArr` when changing calls

Instead of marking a call as listened the moment it is `setSelected`, mark the previously selected call as listened just before changing the selection.

* Improve user experience by showing the selected call in the filtered list while it is playing when hide listened is enabled.
* Fix #17 by allowing `playNext` to find the position of the currently playing call when hide listened is enabled.

# always set `autoPlay="true"`

Always set `autoPlay="true"` for the `audio` tag. This autoplay determines whether the clip starts playing when the source is changed. I consider it to be independent of the toggle button autoplay, which seems to indicate, _"continue playing calls from the `filteredCalls` list without additional input"_

With `autoPlay="true"` the up/down hot keys and tapping/clicking calls in the list immediately starts playback without having to also hit the play button on the player controls.

# Partially address #14

Calls that don't play won't be marked as listened immedately.